### PR TITLE
Add continuous deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: git config
       run: |
         git config --global user.email "docusaurus@example.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-18.04
+    defaults:
+      run:
+        working-directory: website
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: git config
+      run: |
+        git config --global user.email "docusaurus@example.com"
+        git config --global user.name "docusaurus"
+    - run: yarn install
+    - run: yarn deploy
+      env:
+        GIT_USER: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
興味本位でデプロイ用の GitHub Actions を作ってみたので PR 送ってみます。
不要でしたらお手数ですがクローズしてしまってください。（ブログのネタになるかなと作ってみただけなので…！）

フォークしたリポジトリで[動作確認](https://github.com/SnowCait/before_join_socialgame/actions?query=workflow%3ADeploy)をして `gh-pages` ブランチにコミット＆プッシュされるところまでは確認したのですが、 `yarn deploy` を動かすためには `docusaurus.config.js` を書き換える必要があって PR とは状態が少し異なっています。
そのためマージしてそのまま動作してくれるかはやや不明瞭なのですがもしそれでもよろしければ。
トリガー部分や `git config` は適当なものに書き換えた方が良いと思うので指定いただければ対応します。
